### PR TITLE
Possible fix to occasional error with /logvisitor

### DIFF
--- a/app/assets/javascripts/redirect.js
+++ b/app/assets/javascripts/redirect.js
@@ -12,7 +12,7 @@ function setRedirectToHome() {
     if (document.origin != '') {
       $('ul.vertical-nav').animate({left: '-200%'}, 500, function() {
         setTimeout(function(){
-          $.post('/logvisitor').done(function() {
+          $.post('/logvisitor?' + (new Date().getTime()), {authenticity_token: document.csrf}).done(function() {
             window.location = "/";
           });
         }, 500);

--- a/app/controllers/administration_controller.rb
+++ b/app/controllers/administration_controller.rb
@@ -95,9 +95,9 @@ class AdministrationController < ApplicationController
         {
           start_date: start_date,
           end_date: end_date
-        })
+        }).order(:start)
     else
-      @visits = Visitor.where("start is not null")
+      @visits = Visitor.where("start is not null").order(:start)
     end
 
     case params[:group]


### PR DESCRIPTION
I could not reproduce the issue.

However, from looking at the error message, a CSRF token was sent, but it didn't match the one the server thought it should be. This error seems likely to stem from a caching issue, because iOS apparently doesn't respect no-cache, and activity preceding the error looked legitimate. This fix adds a timestamp to each /logvisitor request and an accompanying POST parameter that is probably unnecessary.