### PR TITLE
Maps now pass all linter checks

### DIFF
--- a/doc/floor0.svg
+++ b/doc/floor0.svg
@@ -841,17 +841,13 @@
 		
 			<line id="Elev.3.floor3" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="202.0156" y1="227.3164" x2="200.6406" y2="206.0859"/>
 		
-			<line id="Elev.3.floor4" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="202.0156" y1="227.3164" x2="199.415" y2="205.377"/>
-		
 			<line id="Stair.3.floor2" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="207.4639" y1="231.3311" x2="220.7881" y2="210.584"/>
 		
 			<line id="Stair.3.floor3" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="207.4639" y1="231.3311" x2="220.127" y2="208.4238"/>
 		
-			<line id="Stair.3.floor4" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="207.4639" y1="231.3311" x2="219.709" y2="206.002"/>
-		
 			<line id="Stair.3.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="207.4639" y1="231.3311" x2="221.416" y2="212.375"/>
 		
-			<line id="Stair.1.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="321.0254" y1="77.0732" x2="337.0117" y2="60.4751"/>
+			<line id="Stair.1a.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="321.0254" y1="77.0732" x2="337.0117" y2="60.4751"/>
 		
 			<line id="Elev.1.floor5" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="286.9707" y1="49.311" x2="252.9453" y2="47.502"/>
 		
@@ -867,7 +863,7 @@
 		
 			<line id="Stair.15.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="461.2627" y1="80.75" x2="473.8027" y2="63.709"/>
 		
-			<line id="Stair.2.floor1_1_" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="348.916" y1="175.168" x2="339.4297" y2="151.3535"/>
+			<line id="Stair.2a.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="348.916" y1="175.168" x2="339.4297" y2="151.3535"/>
 		
 			<line id="Elev.2.floor4" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="362.8818" y1="166.1523" x2="371.9707" y2="150.25"/>
 		
@@ -883,27 +879,23 @@
 		
 			<line id="Elev.4.floor2" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="524.0557" y1="110.1572" x2="560.9167" y2="182.6875"/>
 		
-			<line id="Elev.4.floor1_1_" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="524.0557" y1="110.1572" x2="557.3333" y2="62.4167"/>
+			<line id="Elev.4.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="524.0557" y1="110.1572" x2="557.3333" y2="62.4167"/>
 		
-			<line id="Stair.8.floor1_1_" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="106.666" y1="298.7285" x2="113.8848" y2="326.417"/>
+			<line id="Stair.8a.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="106.666" y1="298.7285" x2="113.8848" y2="326.417"/>
 		
-			<line id="Stair.8.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="155.2378" y1="320.7793" x2="123.103" y2="327.334"/>
+			<line id="Stair.8b.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="155.2378" y1="320.7793" x2="123.103" y2="327.334"/>
 		
 			<line id="Stair.13.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="208.8535" y1="93.688" x2="225.9258" y2="84.1611"/>
 		
-			<line id="Stair.12.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="251.7051" y1="135.3682" x2="271.4209" y2="143.7412"/>
+			<line id="Stair.12a.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="251.7051" y1="135.3682" x2="271.4209" y2="143.7412"/>
 		
 			<line id="Stair.11.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="273.6523" y1="221.8184" x2="267.3018" y2="228.1699"/>
 		
-			<line id="Stair.10.floor1_1_" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="429.8506" y1="180.4766" x2="409.1953" y2="179.8457"/>
+			<line id="Stair.10.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="429.8506" y1="180.4766" x2="409.1953" y2="179.8457"/>
 		
 			<line id="Stair.9.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="507.9121" y1="80.5161" x2="507.9121" y2="67.355"/>
 		
-			<line id="Stair.4.floor1_1_" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="525.1709" y1="170.2451" x2="525.1709" y2="134.9531"/>
-		
-			<line id="Stair.1100.floor1" fill="#079948" stroke="#000000" stroke-miterlimit="10" x1="105.5498" y1="237.6445" x2="80.4858" y2="220.1797"/>
-		
-			<line id="Stair.1100.floor1_1_" fill="#079948" stroke="#000000" stroke-miterlimit="10" x1="110.2988" y1="269.792" x2="91.1992" y2="292.5752"/>
+			<line id="Stair.4.floor1" fill="#079948" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="525.1709" y1="170.2451" x2="525.1709" y2="134.9531"/>
 	</g>
 	<g id="Doors">
 		
@@ -996,10 +988,6 @@
 			<line id="R0240_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="485.8125" y1="90.5098" x2="490.4063" y2="85.918"/>
 		
 			<line id="R0241_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="486.1523" y1="101.5659" x2="489.1787" y2="101.5659"/>
-		<path id="R0090_3_" fill="#231F20" stroke="#231F20" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M223.2813,252.8438"/>
-		<path id="R0090_2_" fill="#231F20" stroke="#231F20" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M222.5,243.9872"/>
 		
 			<line id="R0239_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="473.916" y1="101.8071" x2="477.207" y2="105.1001"/>
 		
@@ -1157,13 +1145,19 @@
 		
 			<line id="R0070_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="179.0049" y1="280.4453" x2="175.3301" y2="287.5"/>
 		
-			<line id="R0090_1_" fill="none" stroke="#231F20" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="225.833" y1="247.5342" x2="225.833" y2="255.1905"/>
+			<line id="R0070_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="225.833" y1="247.5342" x2="225.833" y2="255.1905"/>
 		
-			<line id="R0090_4_" fill="none" stroke="#231F20" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="243.8408" y1="230.8311" x2="244.0415" y2="237.3906"/>
+			<line id="R0070_1_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="243.8408" y1="230.8311" x2="244.0415" y2="237.3906"/>
+
+			<line id="R1100_3_" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="111.8662" y1="225.8437" x2="106" y2="231"/>
+
+			<line id="R1100_4" fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="118.2378" y1="280.4453" x2="114" y2="275"/>
 	</g>
 	<g id="Paths">
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="345.8857" y1="185.1572" x2="342.751" y2="188.9766"/>
+
+			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="190.5718" y1="211.6699" x2="238.2734" y2="187.6465"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="155.2378" y1="320.7793" x2="155.0059" y2="279.4414"/>
 		
@@ -1276,13 +1270,7 @@
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="132.0098" y1="224.1016" x2="131.457" y2="203.999"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="170.1519" y1="243.8145" x2="131.457" y2="203.999"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M104.8589,208.7129"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M131.457,203.999"/>
-		
+
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="131.457" y1="203.999" x2="161.6958" y2="183.54"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="161.6958" y1="183.54" x2="169.3062" y2="183.1465"/>
@@ -1360,20 +1348,8 @@
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="302.4961" y1="145.689" x2="363.833" y2="114.5059"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="363.833" y1="114.5059" x2="348.8223" y2="89.3291"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M337.2383,94.002"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M348.8223,89.3291"/>
-		
+
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="348.8223" y1="89.3291" x2="375.6689" y2="78.502"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M374.8926,68.8359"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M375.6689,78.502"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="375.6689" y1="78.502" x2="418.666" y2="78.502"/>
 		
@@ -1639,12 +1615,6 @@
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="296.6875" y1="52.2622" x2="292.4727" y2="54.9648"/>
 		
-			<path fill="#EE223B" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M293.4102,46.7539"/>
-		
-			<path fill="#EE223B" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M296.6875,52.2622"/>
-		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="293.4102" y1="46.7539" x2="297.8164" y2="43.8721"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="293.4102" y1="46.7539" x2="286.9707" y2="49.311"/>
@@ -1707,7 +1677,7 @@
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="459.498" y1="95.377" x2="459.8281" y2="90.5981"/>
 		
-			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="459.8281" y1="95.1411" x2="466.6377" y2="95.4893"/>
+			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="459.498" y1="95.377" x2="466.6377" y2="95.4893"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="466.6377" y1="95.4893" x2="466.0557" y2="106.8643"/>
 		
@@ -1867,7 +1837,7 @@
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="448.2959" y1="199.0957" x2="448.3467" y2="194.0684"/>
 		
-			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="448.1914" y1="198.7187" x2="456.7363" y2="199.0176"/>
+			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="448.2959" y1="199.0957" x2="456.7363" y2="199.0176"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="456.7363" y1="199.0176" x2="457.083" y2="193.7539"/>
 		
@@ -1920,11 +1890,7 @@
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="114.1631" y1="199.8164" x2="131.457" y2="203.999"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="114.1631" y1="199.8164" x2="141.1519" y2="164.3203"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="111.8662" y1="225.8437" x2="118.2378" y2="280.4453"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="111.8662" y1="225.8437" x2="105.5498" y2="237.6445"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="118.2378" y1="280.4453" x2="110.2988" y2="269.792"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="105.5498" y1="237.6445" x2="110.2988" y2="269.792"/>
-		
+
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="525.1709" y1="172.6611" x2="516.9941" y2="172.458"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="516.9941" y1="172.458" x2="484.1992" y2="171.6465"/>
@@ -1945,16 +1911,11 @@
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="235.3271" y1="224.3047" x2="243.8408" y2="230.8311"/>
 		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M104.8589,208.7129"/>
-		
-			<path fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M115.3469,207.0029"/>
-		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="115.3469" y1="207.0029" x2="118.2378" y2="212.75"/>
 		
 			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="118.2378" y1="212.75" x2="123.166" y2="224.2305"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="104.8589" y1="208.7129" x2="115.3469" y2="207.0029"/>
+
+			<line fill="none" stroke="#231F20" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="104.8589" y1="208.7129" x2="115.3469" y2="207.0029"/>
 	</g>
 </g>
 <g id="stairs">

--- a/doc/floor1.svg
+++ b/doc/floor1.svg
@@ -1198,19 +1198,21 @@
 		
 			<line id="Elev.1.floor5" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="297.187" y1="605.0689" x2="297.3872" y2="602.8706"/>
 		
-			<line id="Stair.1.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="296.9873" y2="615.9702"/>
+			<line id="Stair.1b.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="296.9873" y2="615.9702"/>
 		
-			<line id="Stair.1.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="294.3872" y2="616.3706"/>
+			<line id="Stair.1b.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="294.3872" y2="616.3706"/>
 		
-			<line id="Stair.1.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="291.687" y2="616.0689"/>
+			<line id="Stair.1b.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="291.687" y2="616.0689"/>
 		
-			<line id="Stair.1.floor5" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="290.187" y2="613.3706"/>
+			<line id="Stair.1b.floor5" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.7871" y1="613.27" x2="290.187" y2="613.3706"/>
 		
-			<line id="Stair.1.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="326.3872" y1="622.27" x2="437.5376" y2="650.5205"/>
+			<line id="Stair.1a.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="326.3872" y1="622.27" x2="437.5376" y2="650.5205"/>
 		
-			<line id="Stair.12.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="288.7871" y1="716.8706" x2="291.7871" y2="719.8706"/>
+			<line id="Stair.12b.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="288.7871" y1="716.8706" x2="291.7871" y2="719.8706"/>
 		
-			<line id="Stair.12.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="273.7871" y1="702.8706" x2="269.2871" y2="698.77"/>
+			<line id="Stair.12a.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="273.7871" y1="702.8706" x2="269.2871" y2="698.77"/>
+
+			<line id="Stair.13.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="232.0869" y1="636.8706" x2="225" y2="643"/>
 		
 			<line id="Elev.3.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="212.0869" y1="783.3701" x2="209.7871" y2="781.1709"/>
 		
@@ -1218,53 +1220,47 @@
 		
 			<line id="Elev.3.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="212.0869" y1="783.3701" x2="215.2871" y2="781.6709"/>
 		
-			<line id="Elev.3.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="212.0869" y1="783.3701" x2="215.8872" y2="784.8701"/>
-		
 			<line id="Stair.3.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="203.3872" y1="780.2705" x2="208.2871" y2="775.7705"/>
 		
 			<line id="Stair.3.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="217.187" y1="790.3701" x2="218.7871" y2="786.3701"/>
 		
 			<line id="Stair.3.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="217.187" y1="790.3701" x2="221.3872" y2="785.7705"/>
 		
-			<line id="Stair.3.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="217.187" y1="790.3701" x2="224.2871" y2="785.4697"/>
+			<line id="Stair.18.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="515.8857" y1="766.9697" x2="591.1874" y2="766.9697"/>
 		
-			<line id="Stair.18.floor2_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="515.8857" y1="766.9697" x2="591.1874" y2="766.9697"/>
-		
-			<line id="Stair.18.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="515.8857" y1="760.3701" x2="591.1874" y2="760.3701"/>
+			<line id="Stair.18.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="515.8857" y1="760.3701" x2="591.1874" y2="760.3701"/>
 		
 			<line id="Stair.4.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="540.3857" y1="702.0689" x2="540.3857" y2="735.8697"/>
 		
-			<line id="Elev.4.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.9883" y1="665.27" x2="517.8857" y2="638.1694"/>
+			<line id="Elev.4.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.9883" y1="665.27" x2="517.8857" y2="638.1694"/>
 		
-			<line id="Elev.4.floor2_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.9883" y1="665.27" x2="529.5869" y2="693.5689"/>
+			<line id="Elev.4.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.9883" y1="665.27" x2="529.5869" y2="693.5689"/>
 		
 			<line id="Stair.15.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="476.8858" y1="640.8706" x2="479.9883" y2="640.8706"/>
 		
 			<line id="Stair.15.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="476.9883" y1="635.0689" x2="480.3858" y2="635.0689"/>
 		
-			<line id="Stair.9.floor0_3_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="493.2871" y1="623.3706" x2="507.0869" y2="623.3706"/>
+			<line id="Stair.7.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="78.5869" y1="633.4702" x2="80" y2="625"/>
+
+			<line id="Stair.7.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="78.5869" y1="633.4702" x2="84" y2="621"/>
+
+			<line id="Stair.7.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="78.5869" y1="633.4702" x2="88" y2="617"/>
+
+			<line id="Stair.9.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="523.0869" y1="610.6694" x2="523.0869" y2="620.6694"/>
 		
-			<line id="Stair.9.floor0_2_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="523.0869" y1="610.6694" x2="523.0869" y2="620.6694"/>
+			<line id="Stair.2a.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="365.9883" y1="722.77" x2="363.4883" y2="718.8706"/>
 		
-			<line id="Stair.9.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="549.5869" y1="623.4702" x2="538.8857" y2="623.4702"/>
+			<line id="Stair.2b.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="390.7871" y2="713.1694"/>
 		
-			<line id="Stair.19.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="431.2871" y1="799.5693" x2="433.6875" y2="804.2705"/>
+			<line id="Stair.2b.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="389.1875" y2="711.5689"/>
 		
-			<line id="Stair.19.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="431.2871" y1="799.5693" x2="436.3858" y2="804.7705"/>
+			<line id="Stair.2b.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="386.6875" y2="710.4702"/>
 		
-			<line id="Stair.2.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="365.9883" y1="722.77" x2="363.4883" y2="718.8706"/>
+			<line id="Stair.2b.floor5" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="383.9883" y2="710.27"/>
 		
-			<line id="Stair.2.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="390.7871" y2="713.1694"/>
+			<line id="Elev.2.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.5869" y1="717.4702" x2="372.0869" y2="718.4702"/>
 		
-			<line id="Stair.2.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="389.1875" y2="711.5689"/>
-		
-			<line id="Stair.2.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="386.6875" y2="710.4702"/>
-		
-			<line id="Stair.2.floor5" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="391.1875" y1="717.3706" x2="383.9883" y2="710.27"/>
-		
-			<line id="Elev.2.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.5869" y1="717.4702" x2="372.0869" y2="718.4702"/>
-		
-			<line id="Elev.2.floor2_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.5869" y1="717.4702" x2="375.3867" y2="716.27"/>
+			<line id="Elev.2.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.5869" y1="717.4702" x2="375.3867" y2="716.27"/>
 		
 			<line id="Elev.2.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.5869" y1="717.4702" x2="373.3867" y2="713.9702"/>
 		
@@ -1275,12 +1271,14 @@
 			<line id="Stair.17.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="344.3877" y1="756.9697" x2="341.1865" y2="753.7705"/>
 		
 			<line id="Stair.20.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="310.3872" y1="853.1709" x2="306.3872" y2="849.1709"/>
+
+			<line id="Stair.21.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="235.3872" y1="620.77" x2="240" y2="593"/>
 		
-			<line id="Stair.11.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="275.8872" y1="789.3701" x2="280.3872" y2="784.8701"/>
+			<line id="Stair.11.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="275.8872" y1="789.3701" x2="280.3872" y2="784.8701"/>
 		
-			<line id="Stair.8.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="104.8872" y1="860.1709" x2="117.8872" y2="857.3701"/>
+			<line id="Stair.8a.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="104.8872" y1="860.1709" x2="117.8872" y2="857.3701"/>
 		
-			<line id="Stair.8.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="165.3872" y1="881.3701" x2="166.0869" y2="875.2705"/>
+			<line id="Stair.8b.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="165.3872" y1="881.3701" x2="166.0869" y2="875.2705"/>
 		
 			<line id="Elev.6.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="114.2871" y1="748.27" x2="113.9873" y2="745.4702"/>
 		
@@ -1290,9 +1288,9 @@
 		
 			<line id="Elev.6.floor4" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="114.2871" y1="748.27" x2="114.4873" y2="752.669"/>
 		
-			<line id="Stair.6.floor0_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="112.687" y1="738.5689" x2="107.187" y2="738.8706"/>
+			<line id="Stair.6.floor0" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="112.687" y1="738.5689" x2="107.187" y2="738.8706"/>
 		
-			<line id="Stair.6.floor2_1_" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="111.7871" y1="756.3701" x2="107.8872" y2="755.169"/>
+			<line id="Stair.6.floor2" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="111.7871" y1="756.3701" x2="107.8872" y2="755.169"/>
 		
 			<line id="Stair.6.floor3" fill="none" stroke="#FFEE00" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="111.7871" y1="756.3701" x2="105.3872" y2="756.9697"/>
 		
@@ -1402,7 +1400,9 @@
 		
 			<line id="R1205_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="302.5869" y1="641.4702" x2="308.2871" y2="641.4702"/>
 		
-			<line id="R1254_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="220.187" y1="605.3706" x2="217.0869" y2="602.27"/>
+			<line id="R1155_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="228" y1="613" x2="230" y2="615"/>
+
+			<line id="R1154_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="220.187" y1="605.3706" x2="217.0869" y2="602.27"/>
 		
 			<line id="R1153_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="220.3872" y1="622.4702" x2="224.8872" y2="626.9702"/>
 		
@@ -1500,10 +1500,9 @@
 		
 			<line id="R1118_2_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="63.8872" y1="657.27" x2="60.687" y2="660.4702"/>
 		
-			<line id="R1100_4_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="41.8872" y1="792.5693" x2="57.1943" y2="792.5693"/>
-		
-			<polyline id="R1100_3_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
-			41.8872,847.3701 52.3872,847.3701 57.3872,847.2705 		"/>
+			<line id="R1100_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="49.8872" y1="792.5693" x2="57.1943" y2="792.5693"/>
+
+			<line id="R1100_2_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="49.8872" y1="847.3701" x2="57.1943" y2="847.3701"/>
 		
 			<line id="R1165_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="179.0869" y1="753.7705" x2="174.9873" y2="753.7705"/>
 		
@@ -1603,7 +1602,7 @@
 		
 			<line id="R1252_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="360.3867" y1="699.9702" x2="355.4883" y2="694.9702"/>
 		
-			<line id="R1254_2_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="365.2871" y1="697.9702" x2="365.2871" y2="691.0689"/>
+			<line id="R1254_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="365.2871" y1="697.9702" x2="365.2871" y2="691.0689"/>
 		
 			<line id="R1256_1_" fill="none" stroke="#99FF66" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="375.7871" y1="694.3706" x2="375.7871" y2="688.3706"/>
 		
@@ -1665,9 +1664,6 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="549.6874" y1="685.9702" x2="549.6874" y2="677.1694"/>
 		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M549.287,725.9702"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="549.6874" y1="685.9702" x2="540.3857" y2="685.9702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="540.3857" y1="685.9702" x2="540.3857" y2="702.0689"/>
@@ -1677,27 +1673,6 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="555.9883" y1="651.3706" x2="564.6874" y2="651.3706"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="555.9883" y1="665.27" x2="555.9883" y2="651.3706"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M555.9883,665.27"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M555.9883,677.1694"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M555.9883,677.1694"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M558.6874,725.9702"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M558.6874,725.9702"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M558.6874,741.3706"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M558.6874,751.8701"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="555.9883" y1="665.27" x2="544.9883" y2="665.27"/>
 		
@@ -1753,23 +1728,19 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="640.8706" x2="476.8858" y2="640.8706"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="640.8706" x2="468.1875" y2="635.0689"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="640.8706" x2="468.1875" y2="634"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="635.0689" x2="476.9883" y2="635.0689"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="634" x2="476.9883" y2="635.0689"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="635.0689" x2="468.1875" y2="634.0689"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="634.0689" x2="455.9883" y2="634.0689"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="468.1875" y1="634" x2="455.9883" y2="634.0689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="461.2871" y1="750.2705" x2="468.0869" y2="750.2705"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="455.9883" y1="664.77" x2="445.6875" y2="678.5689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="455.9883" y1="634.0689" x2="455.9883" y2="664.77"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="454.9883" y1="588.9702" x2="455.9883" y2="588.9702"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="308.7871" y1="588.9702" x2="454.9883" y2="588.9702"/>
+
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="308.7871" y1="588.9702" x2="455.9883" y2="588.9702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="267.9873" y1="588.9702" x2="308.7871" y2="588.9702"/>
 		
@@ -1840,12 +1811,6 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="421.5869" y1="753.7705" x2="445.6875" y2="750.2705"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="436.9883" y1="774.2705" x2="458.8858" y2="812.0693"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M425.0869,808.4697"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M434.6875,825.4697"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="425.0869" y1="808.4697" x2="420.5869" y2="810.9697"/>
 		
@@ -1933,7 +1898,7 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="368.3867" y1="726.5689" x2="365.9883" y2="722.77"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="368.5869" y1="734.8706" x2="365.0869" y2="733.27"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="368.9883" y1="735.27" x2="365.0869" y2="733.27"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="368.9883" y1="735.27" x2="360.0869" y2="743.1694"/>
 		
@@ -2265,12 +2230,6 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="305.687" y1="689.0689" x2="306.8872" y2="664.5689"/>
 		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M323.7871,634.77"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M331.8872,650.1694"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="308.7871" y1="588.9702" x2="308.8872" y2="600.27"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="308.8872" y1="600.27" x2="297.187" y2="605.0689"/>
@@ -2287,19 +2246,15 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="318.5869" y1="648.4702" x2="309.4873" y2="653.9702"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="323.7871" y1="634.77" x2="318.5869" y2="626.1694"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="305.4873" y1="633.27" x2="303.0869" y2="628.9702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="305.4873" y1="633.27" x2="299.8872" y2="636.0689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.8872" y1="636.0689" x2="302.5869" y2="641.4702"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.8872" y1="636.0689" x2="296.8872" y2="637.9702"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="299.8872" y1="636.0689" x2="295.8872" y2="638.6694"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="296.8872" y1="637.9702" x2="294.687" y2="633.9702"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="296.8872" y1="637.9702" x2="295.8872" y2="638.6694"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="295.8872" y1="638.6694" x2="294.687" y2="633.9702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="295.8872" y1="638.6694" x2="297.9873" y2="643.1694"/>
 		
@@ -2393,11 +2348,9 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="439.4883" y1="614.9702" x2="439.4883" y2="608.3706"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="439.4883" y1="614.9702" x2="440.2871" y2="614.9702"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="439.4883" y1="614.9702" x2="440.2871" y2="620.4702"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="440.2871" y1="614.9702" x2="440.2871" y2="620.4702"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="440.2871" y1="614.9702" x2="447.3858" y2="614.9702"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="439.4883" y1="614.9702" x2="447.3858" y2="614.9702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="447.3858" y1="614.9702" x2="455.9883" y2="614.77"/>
 		
@@ -2411,7 +2364,7 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.4873" y1="609.6694" x2="220.187" y2="605.3706"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.4873" y1="609.6694" x2="229.2871" y2="614.3706"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.4873" y1="609.6694" x2="228" y2="613"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.4873" y1="609.6694" x2="215.9873" y2="618.1694"/>
 		
@@ -2494,9 +2447,10 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="133.187" y1="700.8706" x2="127.0869" y2="707.0689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="127.0869" y1="707.0689" x2="119.4873" y2="714.6694"/>
-		
-			<polyline fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
-			119.4873,714.6694 120.687,729.0689 121.2871,737.0689 		"/>
+
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="119.4873" y1="714.6694" x2="120.687" y2="729.0689"/>
+
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="121.2871" y1="737.0689" x2="120.687" y2="729.0689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="121.2871" y1="737.0689" x2="112.687" y2="738.5689"/>
 		
@@ -2587,9 +2541,8 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="673.3706" x2="70.7871" y2="668.5689"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="668.5689" x2="64.7871" y2="668.5689"/>
-		
-			<polyline fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
-			70.7871,668.5689 70.7871,657.27 70.7871,657.27 		"/>
+
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="668.5689" x2="70.7871" y2="657.27"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="652.0689" x2="72.3872" y2="650.4702"/>
 		
@@ -2666,6 +2619,8 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="41.8872" y1="767.3701" x2="28.0869" y2="767.3701"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="41.8872" y1="792.5693" x2="41.8872" y2="767.3701"/>
+
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="41.8872" y1="792.5693" x2="49.8872" y2="792.5693"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="66.9873" y1="631.27" x2="72.687" y2="639.3706"/>
 		
@@ -2719,15 +2674,7 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="582.5869" y1="701.5689" x2="582.5869" y2="676.9702"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="477.6875" y1="588.9702" x2="477.6875" y2="619.77"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="477.6875" y1="619.77" x2="493.2871" y2="623.3706"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="523.0869" y1="588.9702" x2="523.0869" y2="610.6694"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="566.787" y1="588.9702" x2="566.787" y2="623.5689"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="566.787" y1="623.5689" x2="549.5869" y2="623.4702"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="510.9883" y1="778.7705" x2="480.7871" y2="847.6709"/>
 		
@@ -2737,29 +2684,9 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="491.5869" y1="647.5689" x2="491.5869" y2="641.9702"/>
 		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M574.6874,757.3701"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M539.5869,757.7705"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="113.8872" y1="671.1694" x2="87.8872" y2="645.77"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="657.27" x2="63.8872" y2="657.27"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="63.8872" y1="657.27" x2="64.7871" y2="668.5689"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M84.0869,677.27"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M83.3872,650.27"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M76.5869,688.77"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M84.0869,677.27"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="305.687" y1="816.7705" x2="303.7871" y2="816.3701"/>
 		
@@ -2780,12 +2707,6 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="202.2871" y1="770.6709" x2="212.4873" y2="760.4697"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="212.4873" y1="760.4697" x2="222.7871" y2="769.8701"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M431.2871,799.5693"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M422.5869,804.3701"/>
 		
 			<line id="_x3C_Path_x3E_" fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="41.8872" y1="832.2705" x2="41.8872" y2="792.5693"/>
 		
@@ -2827,8 +2748,6 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="306.8872" y1="664.5689" x2="322.8872" y2="655.3706"/>
 		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="322.8872" y1="655.3706" x2="331.8872" y2="650.1694"/>
-		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="250.2871" y1="633.27" x2="282.0869" y2="620.2202"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.0869" y1="620.2202" x2="283.2373" y2="614.52"/>
@@ -2844,13 +2763,7 @@
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="445.6875" y1="678.5689" x2="445.6875" y2="691.8706"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="445.6875" y1="691.8706" x2="445.6875" y2="719.5689"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M305.4873,633.27"/>
-		
-			<path fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M309.2871,631.27"/>
-		
+
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="309.2871" y1="631.27" x2="318.5869" y2="626.1694"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="305.4873" y1="633.27" x2="309.2871" y2="631.27"/>
@@ -2859,9 +2772,7 @@
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="464.2871" y1="647.5689" x2="491.5869" y2="647.5689"/>
 		
-			<polyline fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="41.8872,792.5693 52.0869,792.5693 57.1943,792.5693"/>
-		
-			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="57.1943" y1="847.3701" x2="41.8872" y2="847.3701"/>
+			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="49.8872" y1="847.3701" x2="41.8872" y2="847.3701"/>
 		
 			<line fill="none" stroke="#FF0000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="70.7871" y1="652.0689" x2="70.7871" y2="657.27"/>
 	</g>

--- a/doc/floor2.svg
+++ b/doc/floor2.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="643px"
 	 height="343px" viewBox="0 0 643 343" enable-background="new 0 0 643 343" xml:space="preserve">
-<g id="Data" display="none">
+<g id="Data">
 	<g id="Rooms" display="inline" opacity="0.25">
 		<a id="R2116" xlink:href="#" >
 			<g>
@@ -858,16 +858,14 @@
 			<line id="Stair.18.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="502.4023" y1="204.5" x2="523.7344" y2="242.4316"/>
 		
 			<line id="Stair.19.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="428.0879" y1="245.6426" x2="498.0938" y2="247.7227"/>
+
+			<line id="Stair.2b.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="409.3379" y2="139.8984"/>
 		
-			<line id="Stair.19.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="422.1133" y1="247.5645" x2="493.1973" y2="242.6719"/>
+			<line id="Stair.2b.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="409.4941" y2="136.6826"/>
 		
-			<line id="Stair.2.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="409.3379" y2="139.8984"/>
+			<line id="Stair.2b.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="406.0215" y2="132.3374"/>
 		
-			<line id="Stair.2.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="409.4941" y2="136.6826"/>
-		
-			<line id="Stair.2.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="379.9102" y1="161.3335" x2="406.0215" y2="132.3374"/>
-		
-			<line id="Stair.2.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.0137" y1="165.1812" x2="394.0703" y2="134.5635"/>
+			<line id="Stair.2b.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="373.0137" y1="165.1812" x2="394.0703" y2="134.5635"/>
 		
 			<line id="Elev.2.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="362.416" y1="162.2515" x2="383.3789" y2="139.8984"/>
 		
@@ -879,21 +877,17 @@
 		
 			<line id="Stair.17.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="323.127" y1="189.5156" x2="350.4961" y2="227.709"/>
 		
-			<line id="Stair.12.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="273.0347" y1="164.5015" x2="290.4795" y2="180.2168"/>
+			<line id="Stair.12b.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="273.0347" y1="164.5015" x2="290.4795" y2="180.2168"/>
 		
 			<line id="Stair.20.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="291.6045" y1="286.8594" x2="322.0957" y2="294.4668"/>
 		
 			<line id="Stair.3.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="206.3457" y1="233.3398" x2="236.9907" y2="223.166"/>
-		
-			<line id="Stair.3.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="206.3457" y1="233.3398" x2="241.9707" y2="225.2617"/>
 		
 			<line id="Stair.3.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="194.3174" y1="221.1094" x2="198.1597" y2="174.4434"/>
 		
 			<line id="Stair.3.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="194.3174" y1="221.1094" x2="200.6465" y2="177.7012"/>
 		
 			<line id="Elev.3.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="200.5713" y1="226.2988" x2="163.0815" y2="233.9902"/>
-		
-			<line id="Elev.3.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="200.5713" y1="226.2988" x2="164.8237" y2="235.8926"/>
 		
 			<line id="Elev.3.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="200.5713" y1="226.2988" x2="165.4634" y2="238.6328"/>
 		
@@ -921,33 +915,25 @@
 		
 			<line id="Stair.7.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="67.3477" y1="75.6167" x2="68.7144" y2="46.2236"/>
 		
-			<line id="Stair.7.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="67.3477" y1="75.6167" x2="67.4463" y2="44.7354"/>
-		
 			<line id="Stair.21.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="209.2676" y1="49.8604" x2="244.8433" y2="68.8716"/>
 		
-			<line id="Stair.1.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="248.7876" y2="42.4595"/>
+			<line id="Stair.1b.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="248.7876" y2="42.4595"/>
 		
-			<line id="Stair.1.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="247.7373" y2="44.7354"/>
+			<line id="Stair.1b.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="247.7373" y2="44.7354"/>
 		
-			<line id="Stair.1.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="246.7886" y2="47.0596"/>
+			<line id="Stair.1b.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="282.3247" y1="39.3726" x2="246.7886" y2="47.0596"/>
 		
-			<line id="Stair.1.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="291.6543" y1="54.6597" x2="288.4146" y2="55.6924"/>
+			<line id="Stair.1b.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="291.6543" y1="54.6597" x2="288.4146" y2="55.6924"/>
 		
-			<line id="Elev.5.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="260.8613" y2="57.0635"/>
+			<line id="Elev.1.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="260.8613" y2="57.0635"/>
 		
-			<line id="Elev.5.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="260.2036" y2="59.0425"/>
+			<line id="Elev.1.floor4" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="260.2036" y2="59.0425"/>
 		
-			<line id="Elev.5.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="259.2354" y2="61.1235"/>
+			<line id="Elev.1.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="259.2354" y2="61.1235"/>
 		
-			<line id="Elev.5.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="263.0894" y2="60.3413"/>
+			<line id="Elev.1.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="263.0894" y2="60.3413"/>
 		
-			<line id="Elev.5.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="218.7813" y2="95.5994"/>
-		
-			<path id="Stair.16.floor1_2_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M304.2515,118.8926"/>
-		
-			<path id="Stair.16.floor1_1_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.6543,106.8403"/>
+			<line id="Elev.1.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.3354" y1="46.3604" x2="218.7813" y2="95.5994"/>
 	</g>
 	<g id="Doors" display="inline">
 		
@@ -1084,18 +1070,6 @@
 			<line id="R2202_1_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="291.1846" y1="29.0317" x2="300.8057" y2="29.0317"/>
 		
 			<line id="R2203_1_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="307.1978" y1="83.8516" x2="297.4336" y2="83.8516"/>
-		
-			<path id="R2203_6_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M273.9907,78.3335"/>
-		
-			<path id="R2203_3_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M266.9673,78.3335"/>
-		
-			<path id="R2203_5_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M284.3413,87.1636"/>
-		
-			<path id="R2203_4_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M284.3413,92.6494"/>
 		
 			<line id="R2204_1_" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="310.9985" y1="61.0244" x2="310.9985" y2="55.6924"/>
 		
@@ -1367,11 +1341,9 @@
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.3398" y1="188.9141" x2="544.3398" y2="195.0801"/>
 		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.3398" y1="195.0801" x2="545.0273" y2="195.0801"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.3398" y1="195.0801" x2="545.0273" y2="200.8242"/>
 		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="545.0273" y1="195.0801" x2="545.0273" y2="200.8242"/>
-		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="545.0273" y1="195.0801" x2="556.1582" y2="195.0801"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="544.3398" y1="195.0801" x2="556.1582" y2="195.0801"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="556.1582" y1="195.0801" x2="556.1582" y2="200.9766"/>
 		
@@ -1649,7 +1621,7 @@
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.6113" y1="223.7949" x2="228.5356" y2="227.7187"/>
 		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.6113" y1="223.7949" x2="213.9507" y2="213.1348"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="224.6113" y1="223.7949" x2="213.9844" y2="213.1016"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="186.1934" y1="205.668" x2="184.2847" y2="203.7598"/>
 		
@@ -1801,9 +1773,7 @@
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="180.7896" y1="86.2676" x2="185.4404" y2="81.6157"/>
 		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="185.4404" y1="81.6157" x2="186.1895" y2="82.3647"/>
-		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="186.1895" y1="82.3647" x2="189.3086" y2="79.2456"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="185.4404" y1="81.6157" x2="189.3086" y2="79.2456"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="185.4404" y1="81.6157" x2="178.1064" y2="74.2817"/>
 		
@@ -1941,36 +1911,6 @@
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="286.9014" y1="31.8267" x2="291.1846" y2="29.0317"/>
 		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.9683,98.5493"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M284.3413,92.6494"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M261.5044,82.6626"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.9683,98.5493"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M266.9673,78.3335"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M261.5044,82.6626"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M273.9233,101.8423"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.9683,98.5493"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.6543,106.8403"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M273.9233,101.8423"/>
-		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="453.0117" y1="85.6465" x2="462.1934" y2="85.1714"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="496.541" y1="195.0801" x2="496.541" y2="204.5"/>
@@ -1986,24 +1926,6 @@
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="491.6621" y1="195.0801" x2="496.541" y2="195.0801"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="496.541" y1="195.0801" x2="506.9102" y2="195.0801"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.9683,98.5493"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M261.5044,82.6626"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.9683,98.5493"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M271.9233,100.3706"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M271.9233,100.3706"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M278.6543,106.8403"/>
 	</g>
 </g>
 <g id="color">

--- a/doc/floor3.svg
+++ b/doc/floor3.svg
@@ -407,8 +407,6 @@
 	</g>
 	<g id="Portals">
 		
-			<line id="Stair.19.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="425.8369" y1="253.1074" x2="421.8037" y2="250.4219"/>
-		
 			<line id="Stair.19.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="425.8369" y1="253.1074" x2="426.3408" y2="250.1758"/>
 		
 			<line id="Elev.2.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="363.1846" y1="165.2622" x2="361.0391" y2="164.418"/>
@@ -419,21 +417,21 @@
 		
 			<line id="Elev.2.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="363.1846" y1="165.2622" x2="365.3486" y2="160.5161"/>
 		
-			<line id="Stair.2.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="381.1113" y1="163.8848" x2="381.3525" y2="161.6431"/>
+			<line id="Stair.2b.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="381.1113" y1="163.8848" x2="381.3525" y2="161.6431"/>
 		
-			<line id="Stair.2.floor5" fill="none" stroke="#000000" stroke-miterlimit="10" x1="381.1113" y1="163.8848" x2="378.3145" y2="162.0732"/>
+			<line id="Stair.2b.floor5" fill="none" stroke="#000000" stroke-miterlimit="10" x1="381.1113" y1="163.8848" x2="378.3145" y2="162.0732"/>
 		
-			<line id="Stair.2.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="374.7832" y1="166.7441" x2="374.6191" y2="164.1519"/>
+			<line id="Stair.2b.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="374.7832" y1="166.7441" x2="374.6191" y2="164.1519"/>
 		
-			<line id="Stair.2.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="374.7832" y1="166.7441" x2="372.8506" y2="163.7861"/>
+			<line id="Stair.2b.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="374.7832" y1="166.7441" x2="372.8506" y2="163.7861"/>
 		
-			<line id="Stair.1.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="290.3901" y1="55.5732" x2="290.1602" y2="57.9639"/>
+			<line id="Stair.1b.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="290.3901" y1="55.5732" x2="290.1602" y2="57.9639"/>
 		
-			<line id="Stair.1.floor5" fill="none" stroke="#000000" stroke-miterlimit="10" x1="290.3901" y1="55.5732" x2="286.957" y2="56.1719"/>
+			<line id="Stair.1b.floor5" fill="none" stroke="#000000" stroke-miterlimit="10" x1="290.3901" y1="55.5732" x2="286.957" y2="56.1719"/>
 		
-			<line id="Stair.1.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="280.5762" y1="38.875" x2="278.8179" y2="41.2187"/>
+			<line id="Stair.1b.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="280.5762" y1="38.875" x2="278.8179" y2="41.2187"/>
 		
-			<line id="Stair.1.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="280.5762" y1="38.875" x2="276.7012" y2="39.958"/>
+			<line id="Stair.1b.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="280.5762" y1="38.875" x2="276.7012" y2="39.958"/>
 		
 			<line id="Elev.1.floor4" fill="none" stroke="#000000" stroke-miterlimit="10" x1="288.125" y1="47.8418" x2="286.333" y2="46.9648"/>
 		
@@ -467,17 +465,17 @@
 		
 			<line id="Stair.6.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="100.9829" y1="202.5977" x2="92.5" y2="206.5625"/>
 		
-			<line id="Elev.5.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="203.1641" y2="229.4805"/>
+			<line id="Elev.3.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="203.1641" y2="229.4805"/>
 		
-			<line id="Elev.5.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="202.5659" y2="227.1836"/>
+			<line id="Elev.3.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="202.5659" y2="227.1836"/>
 		
-			<line id="Elev.5.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="201.478" y2="224.9502"/>
+			<line id="Elev.3.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="199.792" y1="230.082" x2="201.478" y2="224.9502"/>
 		
-			<line id="Stair.5.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="209.0049" y2="234.832"/>
+			<line id="Stair.3.floor2" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="209.0049" y2="234.832"/>
 		
-			<line id="Stair.5.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="209.5112" y2="232.3398"/>
+			<line id="Stair.3.floor1" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="209.5112" y2="232.3398"/>
 		
-			<line id="Stair.5.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="210.231" y2="229.4805"/>
+			<line id="Stair.3.floor0" fill="none" stroke="#000000" stroke-miterlimit="10" x1="205.1689" y1="235.1387" x2="210.231" y2="229.4805"/>
 	</g>
 	<g id="Doors">
 		<line id="R3102_1_" fill="none" stroke="#000000" stroke-miterlimit="10" x1="75.376" y1="90.23" x2="75.376" y2="84.541"/>
@@ -600,9 +598,8 @@
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="427.6396" y1="276.5029" x2="423.1172" y2="279"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="427.6396" y1="276.5029" x2="424.0371" y2="270.2734"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="424.0371" y1="270.2734" x2="428.7832" y2="267.8691"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="424.0371" y1="270.2734" x2="422.3711" y2="267.0049"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="422.3711" y1="267.0049" x2="417.376" y2="269.7119"/>
-		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="422.3711" y1="267.0049" x2="422.1602" y2="266.3574"/>
+		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="424.0371" y1="270.2734" x2="422.1602" y2="266.3574"/>
+		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="422.1602" y1="266.3574" x2="417.376" y2="269.7119"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="422.1602" y1="266.3574" x2="429.1152" y2="262.4951"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="422.1602" y1="266.3574" x2="417.0215" y2="257.4639"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="417.0215" y1="257.4639" x2="411.3779" y2="260.0039"/>
@@ -730,8 +727,6 @@
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="182.4771" y1="206.165" x2="191" y2="214.6875"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="191" y1="214.6875" x2="180.5801" y2="225.1055"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="180.5801" y1="225.1055" x2="186.064" y2="230.5908"/>
-		<path fill="none" stroke="#000000" stroke-miterlimit="10" d="M194.6802,221.9746"/>
-		<path fill="none" stroke="#000000" stroke-miterlimit="10" d="M186.064,230.5908"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="186.064" y1="230.5908" x2="192.6729" y2="237.2002"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="192.6729" y1="237.2002" x2="199.792" y2="230.082"/>
 		<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="192.6729" y1="237.2002" x2="197.8921" y2="242.418"/>

--- a/doc/floor4.svg
+++ b/doc/floor4.svg
@@ -180,13 +180,13 @@
 		
 			<line id="Elev.1.floor0" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="287.5859" y1="46.396" x2="281.6011" y2="45.438"/>
 		
-			<line id="Stair.2.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="377.5391" y1="160.4141" x2="377.5391" y2="157.373"/>
+			<line id="Stair.2b.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="377.5391" y1="160.4141" x2="377.5391" y2="157.373"/>
 		
-			<line id="Stair.2.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="372.7363" y2="162.063"/>
+			<line id="Stair.2b.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="372.7363" y2="162.063"/>
 		
-			<line id="Stair.2.floor2" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="370.8145" y2="160.4141"/>
+			<line id="Stair.2b.floor2" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="370.8145" y2="160.4141"/>
 		
-			<line id="Stair.2.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="367.5029" y2="160.5371"/>
+			<line id="Stair.2b.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="371.7041" y1="164.9268" x2="367.5029" y2="160.5371"/>
 		
 			<line id="Elev.2.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="361.2637" y1="165.7891" x2="362.6035" y2="162.7769"/>
 		
@@ -218,13 +218,13 @@
 		
 			<line id="Stair.7.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="53.8472" y1="77.2529" x2="57.8452" y2="74.2139"/>
 		
-			<line id="Stair.1.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.6602" y1="53.5029" x2="288.749" y2="56.3262"/>
+			<line id="Stair.1b.floor5" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="289.6602" y1="53.5029" x2="288.749" y2="56.3262"/>
 		
-			<line id="Stair.1.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="276.897" y2="38"/>
+			<line id="Stair.1b.floor3" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="276.897" y2="38"/>
 		
-			<line id="Stair.1.floor2" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="274.606" y2="40.0459"/>
+			<line id="Stair.1b.floor2" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="274.606" y2="40.0459"/>
 		
-			<line id="Stair.1.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="272.644" y2="41.375"/>
+			<line id="Stair.1b.floor1" fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="277.813" y1="39.479" x2="272.644" y2="41.375"/>
 	</g>
 	<g id="Doors">
 		
@@ -293,13 +293,14 @@
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="100.019" y1="145.251" x2="78.207" y2="80.4492"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="115.835" y1="129.9619" x2="55.3901" y2="99.9019"/>
-		
-			<polyline fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
-			55.3901,99.9019 65.6392,91.1641 78.207,80.4492 		"/>
+
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="55.3901" y1="99.9019" x2="65.6392" y2="91.1641"/>
+
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="78.207" y1="80.4492" x2="65.6392" y2="91.1641"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="100.019" y1="145.251" x2="55.3901" y2="99.9019"/>
 		
-			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="115.835" y1="129.9619" x2="77.3042" y2="80.4492"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="115.835" y1="129.9619" x2="78.207" y2="80.4492"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="65.6392" y1="91.1641" x2="59.9048" y2="85.875"/>
 		
@@ -372,15 +373,10 @@
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="344.2656" y1="135.104" x2="348.6211" y2="143.5049"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="348.6211" y1="143.5049" x2="344.126" y2="146.0698"/>
+
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="348.6211" y1="143.5049" x2="352.7305" y2="150.625"/>
 		
-			<polyline fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
-			348.6211,143.5049 352.7305,150.625 356.2471,156.7158 		"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M360.7617,154.4448"/>
-		
-			<path fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
-			M356.2471,156.7158"/>
+			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="356.2471" y1="156.7158" x2="352.7305" y2="150.625"/>
 		
 			<line fill="none" stroke="#000000" stroke-width="0.7087" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="352.7305" y1="150.625" x2="347.8027" y2="153.041"/>
 		

--- a/doc/floor5.svg
+++ b/doc/floor5.svg
@@ -339,19 +339,20 @@
 		</a>
 	</g>
 	<g id="Portals">
-		<line id="Stair.1.floor4" class="floor5_5" x1="275.2" y1="38.9" x2="272" y2="41.1"/>
-		<line id="Stair.1.floor3" class="floor5_5" x1="275.2" y1="38.9" x2="269.4" y2="39.3"/>
-		<line id="Stair.1.floor2" class="floor5_5" x1="275.2" y1="38.9" x2="267.2" y2="37.5"/>
-		<line id="Stair.1.floor1" class="floor5_5" x1="275.2" y1="38.9" x2="266.5" y2="34.8"/>
+		<line id="Stair.1b.floor4" class="floor5_5" x1="275.2" y1="38.9" x2="272" y2="41.1"/>
+		<line id="Stair.1b.floor3" class="floor5_5" x1="275.2" y1="38.9" x2="269.4" y2="39.3"/>
+		<line id="Stair.1b.floor2" class="floor5_5" x1="275.2" y1="38.9" x2="267.2" y2="37.5"/>
+		<line id="Stair.1b.floor1" class="floor5_5" x1="275.2" y1="38.9" x2="266.5" y2="34.8"/>
 		<line id="Elev.1.floor4" class="floor5_5" x1="287.6" y1="46.2" x2="284.2" y2="45.5"/>
 		<line id="Elev.1.floor3" class="floor5_5" x1="287.6" y1="46.2" x2="282.5" y2="47.8"/>
 		<line id="Elev.1.floor2" class="floor5_5" x1="287.6" y1="46.2" x2="282" y2="50.8"/>
 		<line id="Elev.1.floor1" class="floor5_5" x1="287.6" y1="46.2" x2="281.6" y2="54.3"/>
 		<line id="Elev.1.floor0" class="floor5_5" x1="287.6" y1="46.2" x2="283" y2="57.5"/>
-		<line id="Stair.2.floor4" class="floor5_5" x1="376.4" y1="166.1" x2="378.9" y2="163.7"/>
-		<line id="Stair.2.floor3" class="floor5_5" x1="376.4" y1="166.1" x2="375.8" y2="160.4"/>
-		<line id="Stair.2.floor2" class="floor5_5" x1="376.4" y1="166.1" x2="370.9" y2="159.1"/>
-		<line id="Stair.2.floor1" class="floor5_5" x1="376.4" y1="166.1" x2="366.7" y2="159.6"/>
+		<line id="Stair.2b.floor4" class="floor5_5" x1="376.4" y1="166.1" x2="378.9" y2="163.7"/>
+		<line id="Stair.2b.floor3" class="floor5_5" x1="376.4" y1="166.1" x2="375.8" y2="160.4"/>
+		<line id="Stair.2b.floor2" class="floor5_5" x1="376.4" y1="166.1" x2="370.9" y2="159.1"/>
+		<line id="Stair.2b.floor1" class="floor5_5" x1="376.4" y1="166.1" x2="366.7" y2="159.6"/>
+
 	</g>
 	<g id="Doors">
 		<line id="R5202_1_" class="floor5_5" x1="324" y1="86.1" x2="327.2" y2="81.8"/>


### PR DESCRIPTION
The SVGs have been updated to pass all current linter checks. Portal definitions are complete, all vertices are connected, and there are no extraneous paths in the data layer on each floor. Additionally, no vertex is within a 1.25 unit threshold of another vertex, so all paths should be connected properly as well.